### PR TITLE
closehandle

### DIFF
--- a/tests/common/simplethread.cpp
+++ b/tests/common/simplethread.cpp
@@ -34,7 +34,6 @@ void SimpleThread::join()
 {
 	if (thread != nullptr && thread->handle != NULL) {
 		WaitForSingleObject(thread->handle, INFINITE);
-		CloseHandle(thread->handle);
 		thread->handle = NULL;
 	}
 }


### PR DESCRIPTION
it's closed by windows after a minute or so. And if it is this single line leads to appcrash(every time).  
my app could work like testcase 
https://github.com/alexeyneu/tool3/tree/82c521d791586ac1b2a36c1e012142d6d560e147/tool3  
but you'll need monero binaries (either from gui or from main project)  
So it appears if you do start then stop then start again after a minute.  
 https://github.com/alexeyneu/tool3/blob/82c521d791586ac1b2a36c1e012142d6d560e147/tool3/MainFrm.cpp#L366
